### PR TITLE
Fixed error "jsx file not found", bumped package to version "1.0.1".

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,8 @@ example/node_modules
 styleguide
 src/
 webpack.config.js
+example/
+.babelrc
+styleguide.*
+.prettierrc
+.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lupus-ai/mui-currency-textfield",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lupus-ai/mui-currency-textfield",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.10.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lupus-ai/mui-currency-textfield",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Currency input textfield for react with Material-ui style",
   "keywords": [
     "material design",

--- a/src/components/CurrencyTextField/index.js
+++ b/src/components/CurrencyTextField/index.js
@@ -1,1 +1,1 @@
-export { default } from "./CurrencyTextField.jsx"
+export { default } from "./CurrencyTextField"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,9 @@ module.exports = {
         filename: "index.js",
         libraryTarget: "commonjs2",
     },
+    resolve: {
+        extensions: ['.ts', '.js', '.jsx', '.json', '.wasm'],
+    },
     module: {
         rules: [
             {


### PR DESCRIPTION
Webpack was not searching for files with "jsx" endings. This had to explicitly enabled in the webpack.config.js file.

Also reduced the npm package file by excluding the example and other config files.